### PR TITLE
Issue #3: Fix DBI_CryptType crypt

### DIFF
--- a/lib/Apache2/AuthCookieDBI.pm
+++ b/lib/Apache2/AuthCookieDBI.pm
@@ -516,7 +516,7 @@ sub _check_password {
     my %password_checker = (
         'none' => sub { return $password eq $crypted_password; },
         'crypt' => sub {
-            crypt( $password, $crypted_password ) eq $crypted_password;
+            return crypt( $password, $crypted_password ) eq $crypted_password;
         },
         'md5' => sub { return md5_hex($password) eq $crypted_password; },
         'sha256' => sub {

--- a/lib/Apache2/AuthCookieDBI.pm
+++ b/lib/Apache2/AuthCookieDBI.pm
@@ -375,10 +375,10 @@ root and include it.
 This is required and has no default value.
 (NOTE: In AuthCookieDBI versions 1.22 and earlier the secret key either could be
 set in the configuration file itself
-or it could be place in a seperate file with the path configured with
+or it could be placed in a separate file with the path configured with
 C<PerlSetVar WhateverDBI_SecretKeyFile>.
 
-As of version 2.0 you must use  C<WhateverDBI_SecretKey> and not
+As of version 2.0, you must use C<WhateverDBI_SecretKey> and not
 C<PerlSetVar WhateverDBI_SecretKeyFile>.
 
 If you want to put the secret key in a separate file then you can create a
@@ -516,8 +516,7 @@ sub _check_password {
     my %password_checker = (
         'none' => sub { return $password eq $crypted_password; },
         'crypt' => sub {
-            $class->_crypt_digest( $password, $crypted_password ) eq
-                $crypted_password;
+            crypt( $password, $crypted_password ) eq $crypted_password;
         },
         'md5' => sub { return md5_hex($password) eq $crypted_password; },
         'sha256' => sub {
@@ -531,12 +530,6 @@ sub _check_password {
         },
     );
     return $password_checker{$crypt_type}->();
-}
-
-sub _crypt_digest {
-    my ( $class, $plaintext, $encrypted ) = @_;
-    my $salt = substr $encrypted, 0, 2;
-    return crypt $plaintext, $salt;
 }
 
 #-------------------------------------------------------------------------------

--- a/lib/Apache2/AuthCookieDBI.pm
+++ b/lib/Apache2/AuthCookieDBI.pm
@@ -337,7 +337,7 @@ sub _dbi_config_vars {
     }
 
     # Compile module for password encryption, if needed.
-    if ( $c{'DBI_CryptType'} =~ '^sha') {
+    if ( $c{'DBI_CryptType'} =~ /^sha/ ) {
         require Digest::SHA;
     }
 
@@ -372,10 +372,9 @@ random string.  This should be secret; either make the httpd.conf file
 only readable by root, or put the PerlSetVar in a file only readable by
 root and include it.
 
-This is required and has no default value.
-(NOTE: In AuthCookieDBI versions 1.22 and earlier the secret key either could be
-set in the configuration file itself
-or it could be placed in a separate file with the path configured with
+This is required and has no default value.  (NOTE: In AuthCookieDBI versions
+1.22 and earlier the secret key either could be set in the configuration file
+itself or it could be placed in a separate file with the path configured with
 C<PerlSetVar WhateverDBI_SecretKeyFile>.
 
 As of version 2.0, you must use C<WhateverDBI_SecretKey> and not

--- a/t/mock_libs/DBI.pm
+++ b/t/mock_libs/DBI.pm
@@ -35,6 +35,10 @@ sub prepare_cached {
     my ($self, @args) = @_;
     return bless {}, 'DBI::Mock::sth';
 }
+sub quote_identifier {
+    my ($self, $arg) = @_;
+    return $arg;
+}
 
 package DBI::Mock::sth;
 

--- a/t/utils.t
+++ b/t/utils.t
@@ -226,14 +226,14 @@ sub test_check_password_digest_none {
 
 sub test_check_password_digest_crypt {
     my $plaintext_password = 'plaintext password';
-    my $crypt_encrypted
-        = CLASS_UNDER_TEST->_crypt_digest( $plaintext_password,
-        $plaintext_password );
+    my $salt = join('',
+        (('.', '/', 0..9, 'A'..'Z', 'a'..'z')[rand 64, rand 64]));
+    my $crypted_password = crypt( $plaintext_password, $salt );
     Test::More::ok(
         CLASS_UNDER_TEST->_check_password(
-            $plaintext_password, $crypt_encrypted, 'crypt'
+            $plaintext_password, $crypted_password, 'crypt'
         ),
-        '_check_password() success case with crypt digest'
+        '_check_password() success case with crypt'
     );
 
     Test::More::ok(

--- a/t/utils.t
+++ b/t/utils.t
@@ -240,7 +240,7 @@ sub test_check_password_digest_crypt {
         !CLASS_UNDER_TEST->_check_password(
             $plaintext_password, 'no match', 'crypt'
         ),
-        '_check_password() failure case with crypt digest'
+        '_check_password() failure case with crypt'
     );
 
     return TRUE;


### PR DESCRIPTION
Refer to issue #3.

This completely removes the incorrect `_crypt_digest`, but nothing else uses it, I think.

It also fixes a couple of mispellings in the pod text. If you prefer that in a separate PR, I can do that.

Would you like me to update the Changes file as well?