### PR TITLE
Minor whitespace changes

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for Perl extension Apache2::AuthCookieDBI.
      - Fix https://github.com/matisse/Apache-AuthCookieDBI/issues/3
        "DBI_CryptType crypt does not appear to work"
        Changes by Ed Sabol https://github.com/esabol
+
 2.17
      - Added support for Digest::SHA::sha256/384/512_hex digests for passwords.
        This is a response to https://rt.cpan.org/Ticket/Display.html?id=79333
@@ -76,17 +77,15 @@ Revision history for Perl extension Apache2::AuthCookieDBI.
        
        Also some minor documentation changes.
 
-
 2.02 - Tue Apr 12 17:58:40 PDT 2005
        Minor documentation fix. Noted that SecretKeyFile has been
        replaced by SecretKey.
-       
 
-2.0.1 - Fixed bug in  group()
-  It was expecting the list of groups to be already split up.
+2.0.1- Fixed bug in group(). It was expecting the list of groups to be
+       already split up.
 
-2.0 - mod_perl 2 version
+2.0  - mod_perl 2 version
 
-0.01  Mon Apr  3 10:50:32 2000
+0.01 - Mon Apr  3 10:50:32 2000
 	- original version; created by h2xs 1.19
 

--- a/Changes
+++ b/Changes
@@ -52,7 +52,7 @@ Revision history for Perl extension Apache2::AuthCookieDBI.
        - Fixed https://rt.cpan.org/Ticket/Display.html?id=45207
          Hash keys for configuration values were wrong in several places.
        - Improved test coverage a little.
-       
+
 2.04 - Fri Nov 28 15:41:33 PST 2008
        Incorporated bug fix for authen_ses_key() provided by
        Carl Gustafsson. authen_ses_key() was not properly handling
@@ -74,7 +74,7 @@ Revision history for Perl extension Apache2::AuthCookieDBI.
        Incorporated Lance P Cleveland's changes porting module to mod_perl 1.999_22
        (That is, Version 2.0.0-RC5 - April 14, 2005)
        Mainly involves changing almost all references to Apache:: to Apache2::
-       
+
        Also some minor documentation changes.
 
 2.02 - Tue Apr 12 17:58:40 PDT 2005
@@ -87,5 +87,5 @@ Revision history for Perl extension Apache2::AuthCookieDBI.
 2.0  - mod_perl 2 version
 
 0.01 - Mon Apr  3 10:50:32 2000
-	- original version; created by h2xs 1.19
+       - original version; created by h2xs 1.19
 

--- a/lib/Apache2/AuthCookieDBI.pm
+++ b/lib/Apache2/AuthCookieDBI.pm
@@ -580,7 +580,6 @@ sub _dbi_connect {
         return $dbh;
     }
     else {
-
         my $error_message
             = "${class}\tcouldn't connect to $c{'DBI_DSN'} for auth realm $auth_name";
         $class->logger( $r, Apache2::Const::LOG_ERR, $error_message,


### PR DESCRIPTION
I think there should be a blank line after each version in Changes, and a blank line was missing after 2.18 was added for the recent release. Sorry, that triggered my perfectionism/quasi-OCD, and I had to do something about it. While I was adding that, I cleaned up a few other things in Changes and removed a blank line in AuthCookieDBI.pm that I think stylistically shouldn't be there. Definitely does not warrant a release or any sort of acknowledgment just for these trivial changes, of course, but I'd appreciate merging for the future.