### PR TITLE
Prepare for 2.19 release

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Perl extension Apache2::AuthCookieDBI.
 
-2.19 - {{TBD}}
+2.19 - Sun Dec  8 15:06:12 PST 2019
      - Added support for group authorizations on Apache 2.4.x. This addresses
        https://github.com/matisse/Apache-AuthCookieDBI/issues/2 and
        https://rt.cpan.org/Public/Bug/Display.html?id=106663.

--- a/Changes
+++ b/Changes
@@ -1,11 +1,12 @@
 Revision history for Perl extension Apache2::AuthCookieDBI.
 
-{{NEXT_VERSION}} - {{RELEASE_DATETIME}}
+2.19 - {{TBD}}
      - Added support for group authorizations on Apache 2.4.x. This addresses
        https://github.com/matisse/Apache-AuthCookieDBI/issues/2 and
        https://rt.cpan.org/Public/Bug/Display.html?id=106663.
      - Refactored group authorization code.
      - Eliminated duplicate calls of _dbi_config_vars() to improve efficiency.
+     - Added docker directory that contains Dockerfiles for Apache 2.2 and 2.4
        Changes by Ed Sabol https://github.com/esabol
 
 2.18 - Sat Aug 17 12:35:38 PDT 2019

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,15 +1,19 @@
-Build.PL
 Changes
+docker/httpd-2.2/Dockerfile
+docker/httpd-2.4/Dockerfile
+docker/README
 eg/bin/login.pl
 eg/html/login-failed.html
 eg/html/login.html
 generic_reg_auth_scheme.txt
 lib/Apache2/AuthCookieDBI.pm
+lib/Apache2_4/AuthCookieDBI.pm
 LICENSE
 MANIFEST
 MANIFEST.SKIP
 META.yml			Module meta-data (added by MakeMaker)
 README
+README-docker
 schema.sql
 t/basic.t
 t/mock_libs/Apache/DBI.pm
@@ -25,5 +29,3 @@ t/mock_libs/Mock/Tieable.pm
 t/utils.t
 t/utils24.t
 techspec.txt
-Makefile.PL
-META.json

--- a/README
+++ b/README
@@ -9,12 +9,15 @@ checksummed and expire-time checked.
 Version 2.03 and later: mod_perl 1.999_22 and later. Apache::*
 replaced by Apache2::
 
-Latest distribution at: http://search.cpan.org/dist/Apache2-AuthCookieDBI
+Latest distribution at: https://metacpan.org/pod/Apache2::AuthCookieDBI
 Source code at:         https://github.com/matisse/Apache-AuthCookieDBI/
  
 Apache::AuthCookieDBI versions:
 Version 2.0 and later: mod_perl 1.99_XX
 Version 1.22 was the last version that works with mod_perl 1.x
 
+See the README-docker file in this distribution for instructions
+on how to use the `docker` directory to test this distribution
+without needing to install Apache or mod_perl on your local machine.
 
 Maintainer: matisse@cpan.org

--- a/README-docker
+++ b/README-docker
@@ -2,10 +2,10 @@ Assuming you have installed the base Docker software on your machine
 you can run the tests for this distribution without installing
 Apache or mod_perl on your local machine.
 
-Docker allows you to run an entirely different OS as a process
-on your local machine.
+Docker allows you to run an entirely different OS as a process on
+your local machine. See: https://docs.docker.com
 
-See: https://docs.docker.com
+See also: "TESTING DIFFERENT VERSIONS OF Perl/mod_perl" below.
 
 The docker/ directory in this distribution contains:
 
@@ -32,4 +32,29 @@ commands it will take a while for Docker to create the image
 mod_perl so it can take many minutes.) Assuming you don't delete
 the Docker images then subsequent runs will be much faster.
 
-See also the Dockerfile reference: https://docs.docker.com/engine/reference/builder/
+See also the Dockerfile reference:
+https://docs.docker.com/engine/reference/builder/
+
+TESTING DIFFERENT VERSIONS OF Perl/mod_perl
+
+`httpd-2.2/Dockerfile`
+
+The `httpd-2.2/Dockerfile` uses the official Apache Docker image
+for version 2.2.34 and then builds Perl and mod_perl from source.
+
+IMPORTANT: This means you can adapt this Dockerfile to build and
+test with alternative versions of Perl and mod_perl.
+
+`httpd-2.4/Dockerfile`
+
+The `httpd-2.4/Dockerfile` uses the versions of httpd, mod_perl,
+and Perl provided by Ubuntu linux. It does this by using `apt-get`
+to install the vendor packages for apache2 and libapache2-mod-perl2.
+
+This means that building the initial Docker image from this Dockerfile
+takes about 1/7 the time that the `httpd-2.2/Dockerfile` takes to
+build from source but it also means that you cannot use this
+Dockerfile to test alternative versions of httpd, mod_perl, or Perl.
+If you want to do that start with the `httpd-2.2/Dockerfile` and
+modify it.
+

--- a/README-docker
+++ b/README-docker
@@ -1,0 +1,35 @@
+Assuming you have installed the base Docker software on your machine
+you can run the tests for this distribution without installing
+Apache or mod_perl on your local machine.
+
+Docker allows you to run an entirely different OS as a process
+on your local machine.
+
+See: https://docs.docker.com
+
+The docker/ directory in this distribution contains:
+
+  httpd-2.2/
+    Dockerfile
+
+  httpd-2.4/
+    Dockerfile
+
+You can run the following commands from the top level of this
+distribution (it is important that these commands be run from the
+top level of this distro):
+
+   docker build -f docker/httpd-2.2/Dockerfile .
+
+or
+
+   docker build -f docker/httpd-2.4/Dockerfile .
+
+Docker will copy the contents of this distro into the virtual
+container and run the tests.  The first time you run one of those
+commands it will take a while for Docker to create the image
+(especially for the 2.2 version where it actually builds perl and
+mod_perl so it can take many minutes.) Assuming you don't delete
+the Docker images then subsequent runs will be much faster.
+
+See also the Dockerfile reference: https://docs.docker.com/engine/reference/builder/

--- a/docker/README
+++ b/docker/README
@@ -1,0 +1,1 @@
+See README-docker at the top level of this distribution.

--- a/docker/httpd-2.2/Dockerfile
+++ b/docker/httpd-2.2/Dockerfile
@@ -27,7 +27,7 @@ RUN cpan App::cpanminus && \
     rm -rf /tmp/* /root/.cpan /root/.cpanm && \
     mkdir /var/tmp/Apache-AuthCookieDBI
 
-COPY Apache-AuthCookieDBI/ /var/tmp/Apache-AuthCookieDBI
+COPY ./ /var/tmp/Apache-AuthCookieDBI
 
 RUN cd /var/tmp/Apache-AuthCookieDBI/ && \
     perl Build.PL && \

--- a/docker/httpd-2.4/Dockerfile
+++ b/docker/httpd-2.4/Dockerfile
@@ -1,33 +1,19 @@
-FROM httpd:2.4.41
+FROM ubuntu
 
-ENV MOD_PERL_VERSION 2.0.11
-ENV MOD_PERL_SHA256SUM ca2a9e18cdf90f9c6023e786369d5ba75e8dac292ebfea9900c29bf42dc16f74
-ENV PERL_VERSION 5.28.2
-
-ENV PATH /opt/perl-$PERL_VERSION/bin:$PATH
+LABEL maintainer="matisse@cpan.org"
 
 RUN apt-get update && \
-    apt-get install -yq --no-install-recommends perl ca-certificates curl build-essential netbase && \
-    curl -sfL https://raw.githubusercontent.com/tokuhirom/Perl-Build/master/perl-build | perl - $PERL_VERSION /opt/perl-$PERL_VERSION/ -Duseshrplib -j "$(nproc)" && \
-    curl -sfLO http://apache.org/dist/perl/mod_perl-$MOD_PERL_VERSION.tar.gz && \
-    echo "${MOD_PERL_SHA256SUM} *mod_perl-$MOD_PERL_VERSION.tar.gz" | sha256sum -c && \
-    tar xzf mod_perl-$MOD_PERL_VERSION.tar.gz && \
-    cd mod_perl-$MOD_PERL_VERSION && \
-    /opt/perl-$PERL_VERSION/bin/perl Makefile.PL MP_NO_THREADS=1 && \
-    make -j "$(nproc)" && \
-    make install && \
-    cd .. && \
-    rm -rf mod_perl-$MOD_PERL_VERSION mod_perl-$MOD_PERL_VERSION.tar.gz && \
-    apt-get autoremove -yq && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get upgrade -y && \
+    apt-get install -y \
+       apache2 \
+       libapache2-mod-perl2 \
+       libmodule-build-perl \
+       libapache2-authcookie-perl \
+       libdbi-perl \
+       libdate-calc-perl \
+       libcrypt-cbc-perl
 
-RUN cpan App::cpanminus && \
-    cpanm Apache2::AuthCookie && \
-    cpanm Apache2::AuthCookieDBI && \
-    rm -rf /tmp/* /root/.cpan /root/.cpanm && \
-    mkdir /var/tmp/Apache-AuthCookieDBI
-
-COPY Apache-AuthCookieDBI/ /var/tmp/Apache-AuthCookieDBI
+COPY ./ /var/tmp/Apache-AuthCookieDBI
 
 RUN cd /var/tmp/Apache-AuthCookieDBI/ && \
     perl Build.PL && \


### PR DESCRIPTION
Change the docker/httpd-2.4/Dockerfile to use apt-get to install
apache and mod_perl instead of building perl from source.

Add README-docker that describes how to use Docker to test this distro.

Fix a COPY directive in docker/httpd-2.2/Dockerfile to work when
invoked from the top level of this distro.

Update README to mention the docker stuff and use metacpan for
finding this distro.